### PR TITLE
Avoid recalculating entire permission set after every portal removal in a batch.

### DIFF
--- a/src/main/java/com/onarandombox/MultiversePortals/MVPortal.java
+++ b/src/main/java/com/onarandombox/MultiversePortals/MVPortal.java
@@ -167,10 +167,6 @@ public class MVPortal {
         allPortalFill.getChildren().put(this.fillPermission.getName(), true);
 
         this.plugin.getServer().getPluginManager().recalculatePermissionDefaults(all);
-        this.plugin.getServer().getPluginManager().recalculatePermissionDefaults(allPortals);
-        this.plugin.getServer().getPluginManager().recalculatePermissionDefaults(allPortalAccess);
-        this.plugin.getServer().getPluginManager().recalculatePermissionDefaults(allPortalExempt);
-        this.plugin.getServer().getPluginManager().recalculatePermissionDefaults(allPortalFill);
         for(Player player : this.plugin.getServer().getOnlinePlayers()){
             player.recalculatePermissions();
         }


### PR DESCRIPTION
When reloading Multiverse-Portals (as is triggered by Multiverse-Adventure), the server hangs for a bit while permissions are recalculated. The time is dependent on the number of Permissibles, Permissions, and Portals. In my case, the server would lock up for 1:30. Looking at the code, I managed to get it down to roughly half that.

In MVPortal.java, I removed lines 170-173. recalculatePermissionDefaults calculates recursively, so the were already recalculated on line 169.

In PortalManager, rather than recalculating the permission set after removing each portal in a batch, I remove them all, delaying the recalculation until they are all removed.

If I missed anything, or need to correct anything, please let me know.

Many thanks,
Joshua Rogers