### PR TITLE
Fix WorldEdit integration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,10 @@
             <id>Bukkit Official</id>
             <url>http://repo.bukkit.org/content/repositories/public</url>
         </repository>
+        <repository>
+            <id>sk89q-repo</id>
+            <url>http://maven.sk89q.com/repo/</url>
+        </repository>
     </repositories>
 
     <!-- Profiles are used to detect whether this is a local or Jenkins build
@@ -161,7 +165,7 @@
         <dependency>
             <groupId>com.sk89q</groupId>
             <artifactId>worldedit</artifactId>
-            <version>4.7</version>
+            <version>5.6.3</version>
             <type>jar</type>
             <scope>compile</scope>
             <exclusions>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         </repository>
         <repository>
             <id>Bukkit Official</id>
-            <url>http://repo.bukkit.org/content/repositories/public</url>
+            <url>http://repo.bukkit.org/content/groups/public/</url>
         </repository>
         <repository>
             <id>sk89q-repo</id>

--- a/src/main/java/com/onarandombox/MultiversePortals/MultiversePortals.java
+++ b/src/main/java/com/onarandombox/MultiversePortals/MultiversePortals.java
@@ -18,9 +18,6 @@ import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import com.dumptruckman.minecraft.util.Logging;
-import com.onarandombox.MultiversePortals.listeners.MVPPlayerMoveListener;
-import com.onarandombox.MultiversePortals.listeners.PlayerListenerHelper;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.configuration.Configuration;
@@ -31,6 +28,7 @@ import org.bukkit.permissions.Permission;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.java.JavaPlugin;
 
+import com.dumptruckman.minecraft.util.Logging;
 import com.onarandombox.MultiverseCore.MultiverseCore;
 import com.onarandombox.MultiverseCore.api.MVPlugin;
 import com.onarandombox.MultiverseCore.commands.HelpCommand;
@@ -47,15 +45,16 @@ import com.onarandombox.MultiversePortals.commands.WandCommand;
 import com.onarandombox.MultiversePortals.destination.PortalDestination;
 import com.onarandombox.MultiversePortals.destination.RandomPortalDestination;
 import com.onarandombox.MultiversePortals.enums.PortalConfigProperty;
+import com.onarandombox.MultiversePortals.integration.WorldEditHandler;
 import com.onarandombox.MultiversePortals.listeners.MVPBlockListener;
 import com.onarandombox.MultiversePortals.listeners.MVPCoreListener;
 import com.onarandombox.MultiversePortals.listeners.MVPPlayerListener;
+import com.onarandombox.MultiversePortals.listeners.MVPPlayerMoveListener;
 import com.onarandombox.MultiversePortals.listeners.MVPPluginListener;
 import com.onarandombox.MultiversePortals.listeners.MVPVehicleListener;
+import com.onarandombox.MultiversePortals.listeners.PlayerListenerHelper;
 import com.onarandombox.MultiversePortals.utils.PortalManager;
 import com.pneumaticraft.commandhandler.multiverse.CommandHandler;
-import com.sk89q.worldedit.bukkit.WorldEditAPI;
-import com.sk89q.worldedit.bukkit.WorldEditPlugin;
 
 public class MultiversePortals extends JavaPlugin implements MVPlugin {
 
@@ -68,7 +67,8 @@ public class MultiversePortals extends JavaPlugin implements MVPlugin {
     private FileConfiguration MVPConfig;
 
     private CommandHandler commandHandler;
-    protected WorldEditAPI worldEditAPI = null;
+
+    protected WorldEditHandler worldEdit = null;
 
     private PortalManager portalManager;
     private Map<String, PortalPlayerSession> portalSessions;
@@ -86,10 +86,12 @@ public class MultiversePortals extends JavaPlugin implements MVPlugin {
     // An empty or null list means all materials are okay.
     public static List<Integer> FrameMaterials = null;
 
+    @Override
     public void onLoad() {
         getDataFolder().mkdirs();
     }
 
+    @Override
     public void onEnable() {
         this.core = (MultiverseCore) getServer().getPluginManager().getPlugin("Multiverse-Core");
 
@@ -160,10 +162,19 @@ public class MultiversePortals extends JavaPlugin implements MVPlugin {
      * Currently, WorldEdit is required for portals, we're listening for new plugins coming online, but we need to make
      * sure
      */
-    private void checkForWorldEdit() {
-        if (this.getServer().getPluginManager().getPlugin("WorldEdit") != null) {
-            this.worldEditAPI = new WorldEditAPI((WorldEditPlugin) this.getServer().getPluginManager().getPlugin("WorldEdit"));
+    public void checkForWorldEdit() {
+        try {
+            worldEdit = new WorldEditHandler(this);
+        } catch (Throwable ex) {
         }
+    }
+
+    public boolean isWorldEditEnabled() {
+        return worldEdit != null && worldEdit.isEnabled();
+    }
+
+    public WorldEditHandler getWorldEdit() {
+        return worldEdit;
     }
 
     /** Create the higher level permissions so we can add finer ones to them. */
@@ -302,6 +313,7 @@ public class MultiversePortals extends JavaPlugin implements MVPlugin {
         }
     }
 
+    @Override
     public void onDisable() {
 
     }
@@ -353,10 +365,7 @@ public class MultiversePortals extends JavaPlugin implements MVPlugin {
         return authors.substring(2);
     }
 
-    public WorldEditAPI getWEAPI() {
-        return this.worldEditAPI;
-    }
-
+    @Override
     public MultiverseCore getCore() {
         return this.core;
     }
@@ -369,6 +378,7 @@ public class MultiversePortals extends JavaPlugin implements MVPlugin {
         return this.MVPPortalConfig;
     }
 
+    @Override
     public void setCore(MultiverseCore multiverseCore) {
         this.core = multiverseCore;
     }
@@ -389,8 +399,9 @@ public class MultiversePortals extends JavaPlugin implements MVPlugin {
     }
 
     /**
-     * Logs a message to Multiverse-Portals's Logger.  If the Message is of fine-finest level, it will be logged to the
+     * Logs a message to Multiverse-Portals's Logger. If the Message is of fine-finest level, it will be logged to the
      * debug log if enabled.
+     *
      * @param level
      * @param msg
      * @deprecated
@@ -409,10 +420,6 @@ public class MultiversePortals extends JavaPlugin implements MVPlugin {
     @Deprecated
     public static void staticDebugLog(Level level, String msg) {
         Logging.log(level, msg);
-    }
-
-    public void setWorldEditAPI(WorldEditAPI api) {
-        this.worldEditAPI = api;
     }
 
     @Override

--- a/src/main/java/com/onarandombox/MultiversePortals/PortalPlayerSession.java
+++ b/src/main/java/com/onarandombox/MultiversePortals/PortalPlayerSession.java
@@ -10,7 +10,6 @@ package com.onarandombox.MultiversePortals;
 import java.util.Date;
 import java.util.logging.Level;
 
-import com.onarandombox.MultiversePortals.enums.MoveType;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.command.CommandSender;
@@ -18,6 +17,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.util.Vector;
 
 import com.onarandombox.MultiverseCore.api.MultiverseWorld;
+import com.onarandombox.MultiversePortals.enums.MoveType;
 import com.onarandombox.MultiversePortals.utils.MultiverseRegion;
 import com.onarandombox.MultiversePortals.utils.PortalManager;
 
@@ -128,7 +128,7 @@ public class PortalPlayerSession {
     }
 
     public boolean setLeftClickSelection(Vector v, MultiverseWorld world) {
-        if(!this.plugin.isWandEnabled()) {
+        if (!this.plugin.isWandEnabled()) {
             return false;
         }
         this.leftClick = v;
@@ -143,7 +143,7 @@ public class PortalPlayerSession {
     }
 
     public boolean setRightClickSelection(Vector v, MultiverseWorld world) {
-        if(!this.plugin.isWandEnabled()) {
+        if (!this.plugin.isWandEnabled()) {
             return false;
         }
         this.rightClick = v;
@@ -159,36 +159,48 @@ public class PortalPlayerSession {
     }
 
     public MultiverseRegion getSelectedRegion() {
-        // Did not find WE
-        MultiverseRegion r = null;
-        if (this.plugin.getWEAPI() != null) {
-            System.out.println("WEAPI");
+        Player player = getPlayerFromName();
+        if (plugin.isWorldEditEnabled()) {
             try {
-                // GAH this looks SO ugly keeping no imports :( see if I can find a workaround
-                r = new MultiverseRegion(this.plugin.getWEAPI().getSession(this.getPlayerFromName()).getSelection(this.plugin.getWEAPI().getSession(this.getPlayerFromName()).getSelectionWorld()).getMinimumPoint(),
-                        this.plugin.getWEAPI().getSession(this.getPlayerFromName()).getSelection(this.plugin.getWEAPI().getSession(this.getPlayerFromName()).getSelectionWorld()).getMaximumPoint(),
-                        this.plugin.getCore().getMVWorldManager().getMVWorld(this.getPlayerFromName().getWorld().getName()));
-            } catch (Exception e) {
-                this.getPlayerFromName().sendMessage("You haven't finished your selection.");
+                if (!plugin.getWorldEdit().hasSelection(player)) {
+                    player.sendMessage(ChatColor.RED + "You must have a WorldEdit selection to do this!");
+                    return null;
+                }
+
+                Location minimumPoint = plugin.getWorldEdit().getMaxPoint(player);
+                Location maximumPoint = plugin.getWorldEdit().getMinPoint(player);
+                if (minimumPoint == null || maximumPoint == null) {
+                    player.sendMessage(ChatColor.RED + "You must finish your selection first!");
+                    return null;
+                }
+
+                MultiverseWorld mvWorld = plugin.getCore().getMVWorldManager().getMVWorld(player.getWorld().getName());
+                return new MultiverseRegion(maximumPoint, minimumPoint, mvWorld);
+            } catch (Throwable ex) {
+                player.sendMessage(ChatColor.RED + "Encountered an exception, check console!");
+                plugin.getLogger().log(Level.SEVERE, "Failed to get WorldEdit selection for portal creation", ex);
                 return null;
             }
-            return r;
         }
+
         // They're using our crappy selection:
         if (this.leftClick == null) {
-            this.getPlayerFromName().sendMessage("You need to LEFT click on a block with your wand!");
+            player.sendMessage("You need to LEFT click on a block with your wand!");
             return null;
         }
+
         if (this.rightClick == null) {
-            this.getPlayerFromName().sendMessage("You need to RIGHT click on a block with your wand!");
+            player.sendMessage("You need to RIGHT click on a block with your wand!");
             return null;
         }
+
         if (!this.leftClickWorld.equals(this.rightClickWorld)) {
-            this.getPlayerFromName().sendMessage("You need to select both coords in the same world!");
-            this.getPlayerFromName().sendMessage("Left Click Position was in:" + this.leftClickWorld.getColoredWorldString());
-            this.getPlayerFromName().sendMessage("Right Click Position was in:" + this.rightClickWorld.getColoredWorldString());
+            player.sendMessage("You need to select both coords in the same world!");
+            player.sendMessage("Left Click Position was in:" + this.leftClickWorld.getColoredWorldString());
+            player.sendMessage("Right Click Position was in:" + this.rightClickWorld.getColoredWorldString());
             return null;
         }
+
         return new MultiverseRegion(this.leftClick, this.rightClick, this.leftClickWorld);
     }
 
@@ -296,8 +308,8 @@ public class PortalPlayerSession {
     }
 
     public String getFriendlyRemainingTimeMessage() {
-        String remaining = "There is a portal " + ChatColor.AQUA + "cooldown" + ChatColor.WHITE + " in effect. Please try again in " + ChatColor.GOLD
-        + Integer.toString((int) this.getRemainingCooldown() / 1000) + "s.";
+        String remaining = "There is a portal " + ChatColor.AQUA + "cooldown" + ChatColor.WHITE + " in effect. Please try again in "
+                + ChatColor.GOLD + Integer.toString((int) this.getRemainingCooldown() / 1000) + "s.";
         int time = (int) this.getRemainingCooldown() / 1000;
         // Account for the fact that 0 seconds means 1
         time++;
@@ -310,7 +322,7 @@ public class PortalPlayerSession {
     }
 
     public long getRemainingCooldown() {
-        //Calculate the remaining cooldown period
+        // Calculate the remaining cooldown period
         long remainingcooldown = (this.plugin.getCooldownTime() - ((new Date()).getTime() - this.lastTeleportTime.getTime()));
         if (remainingcooldown < 0) {
             remainingcooldown = 0;

--- a/src/main/java/com/onarandombox/MultiversePortals/commands/WandCommand.java
+++ b/src/main/java/com/onarandombox/MultiversePortals/commands/WandCommand.java
@@ -50,7 +50,7 @@ public class WandCommand extends PortalCommand {
         // Do the normal wand thing
         if (sender instanceof Player) {
             Player p = (Player) sender;
-            if (this.plugin.getWEAPI() != null) {
+            if (plugin.isWorldEditEnabled()) {
                 p.sendMessage(ChatColor.GREEN + "Cool!" + ChatColor.WHITE + " You're using" + ChatColor.AQUA + " WorldEdit! ");
                 p.sendMessage("Just use " + ChatColor.GOLD + "the WorldEdit wand " + ChatColor.WHITE + "to perform portal selections!");
                 return;

--- a/src/main/java/com/onarandombox/MultiversePortals/integration/WorldEditHandler.java
+++ b/src/main/java/com/onarandombox/MultiversePortals/integration/WorldEditHandler.java
@@ -1,0 +1,62 @@
+package com.onarandombox.MultiversePortals.integration;
+
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+
+import com.onarandombox.MultiversePortals.MultiversePortals;
+import com.sk89q.worldedit.bukkit.WorldEditPlugin;
+import com.sk89q.worldedit.bukkit.selections.Selection;
+
+/**
+ * @author dmulloy2
+ */
+
+public class WorldEditHandler {
+    private WorldEditPlugin worldEdit;
+
+    public WorldEditHandler(MultiversePortals plugin) {
+        try {
+            worldEdit = (WorldEditPlugin) plugin.getServer().getPluginManager().getPlugin("WorldEdit");
+            plugin.getLogger().info("Found WorldEdit, using it for selections.");
+        } catch (Throwable ex) {
+        }
+    }
+
+    public boolean isEnabled() {
+        return worldEdit != null;
+    }
+
+    public Location getMaxPoint(Player player) {
+        if (!isEnabled()) {
+            return null;
+        }
+
+        Selection selection = getSelection(player);
+        return selection != null ? selection.getMaximumPoint() : null;
+    }
+
+    public Location getMinPoint(Player player) {
+        if (!isEnabled()) {
+            return null;
+        }
+
+        Selection selection = getSelection(player);
+        return selection != null ? selection.getMinimumPoint() : null;
+    }
+
+    public Selection getSelection(Player player) {
+        if (!isEnabled()) {
+            return null;
+        }
+
+        return worldEdit.getSelection(player);
+    }
+
+    public boolean hasSelection(Player player) {
+        if (!isEnabled()) {
+            return false;
+        }
+
+        return getSelection(player) != null;
+    }
+}

--- a/src/main/java/com/onarandombox/MultiversePortals/listeners/MVPPlayerListener.java
+++ b/src/main/java/com/onarandombox/MultiversePortals/listeners/MVPPlayerListener.java
@@ -10,8 +10,8 @@ package com.onarandombox.MultiversePortals.listeners;
 import java.util.Date;
 import java.util.logging.Level;
 
-import com.fernferret.allpay.multiverse.commons.GenericBank;
 import net.milkbowl.vault.economy.Economy;
+
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -29,6 +29,7 @@ import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerPortalEvent;
 import org.bukkit.event.player.PlayerTeleportEvent;
 
+import com.fernferret.allpay.multiverse.commons.GenericBank;
 import com.onarandombox.MultiverseCore.api.MVDestination;
 import com.onarandombox.MultiverseCore.api.MultiverseWorld;
 import com.onarandombox.MultiverseCore.api.SafeTTeleporter;
@@ -166,7 +167,7 @@ public class MVPPlayerListener implements Listener {
         // If we Found WorldEdit, return, we're not needed here.
         // If the item is not the Wand we've stetup we're not needed either
         // If the player doesn't have the perms, return also.
-        if (this.plugin.getWEAPI() != null || event.getPlayer().getItemInHand().getTypeId() != itemType || !this.plugin.getCore().getMVPerms().hasPermission(event.getPlayer(), "multiverse.portal.create", true)) {
+        if (plugin.isWorldEditEnabled() || event.getPlayer().getItemInHand().getTypeId() != itemType || !this.plugin.getCore().getMVPerms().hasPermission(event.getPlayer(), "multiverse.portal.create", true)) {
             return;
         }
 

--- a/src/main/java/com/onarandombox/MultiversePortals/listeners/MVPPluginListener.java
+++ b/src/main/java/com/onarandombox/MultiversePortals/listeners/MVPPluginListener.java
@@ -16,8 +16,6 @@ import org.bukkit.event.server.PluginEnableEvent;
 
 import com.onarandombox.MultiverseCore.MultiverseCore;
 import com.onarandombox.MultiversePortals.MultiversePortals;
-import com.sk89q.worldedit.bukkit.WorldEditAPI;
-import com.sk89q.worldedit.bukkit.WorldEditPlugin;
 
 public class MVPPluginListener implements Listener {
 
@@ -33,8 +31,7 @@ public class MVPPluginListener implements Listener {
             this.plugin.setCore(((MultiverseCore) this.plugin.getServer().getPluginManager().getPlugin("Multiverse-Core")));
             this.plugin.getServer().getPluginManager().enablePlugin(this.plugin);
         } else if (event.getPlugin().getDescription().getName().equals("WorldEdit")) {
-            this.plugin.setWorldEditAPI(new WorldEditAPI((WorldEditPlugin) this.plugin.getServer().getPluginManager().getPlugin("WorldEdit")));
-            MultiversePortals.staticLog(Level.INFO, "Found WorldEdit. Using it for selections.");
+            this.plugin.checkForWorldEdit();
         } else if (event.getPlugin().getDescription().getName().equals("MultiVerse")) {
             if (event.getPlugin().isEnabled()) {
                 this.plugin.getServer().getPluginManager().disablePlugin(event.getPlugin());

--- a/src/main/java/com/onarandombox/MultiversePortals/utils/MultiverseRegion.java
+++ b/src/main/java/com/onarandombox/MultiversePortals/utils/MultiverseRegion.java
@@ -23,6 +23,17 @@ public class MultiverseRegion {
     private Vector max;
     private MultiverseWorld world;
 
+    public MultiverseRegion(Vector pos1, Vector pos2, MultiverseWorld w) {
+        this.min = Vector.getMinimum(pos1, pos2);
+        this.max = Vector.getMaximum(pos1, pos2);
+        this.world = w;
+    }
+
+    public MultiverseRegion(Location pos1, Location pos2, MultiverseWorld w) {
+        this(pos1.toVector(), pos2.toVector(), w);
+    }
+
+    @Deprecated
     public MultiverseRegion(Object pos1, Object pos2, MultiverseWorld w) {
         // Creating soft dependencies on WE
         if (pos1 instanceof com.sk89q.worldedit.Vector && pos2 instanceof com.sk89q.worldedit.Vector) {
@@ -34,12 +45,6 @@ public class MultiverseRegion {
             this.max = Vector.getMaximum(tmp1, tmp2);
             this.world = w;
         }
-    }
-
-    public MultiverseRegion(Vector pos1, Vector pos2, MultiverseWorld w) {
-        this.min = Vector.getMinimum(pos1, pos2);
-        this.max = Vector.getMaximum(pos1, pos2);
-        this.world = w;
     }
 
     public Vector getMinimumPoint() {


### PR DESCRIPTION
LocalWorld, a class that isn't needed, was removed in 6.0.0. This broke
Multiverse-Portals' WorldEdit integration and made creating new portals
impossible. This commit fixes this problem by using the Bukkit World,
as well as Bukkit Locations and a separate handler. This will make MVP compatible with WorldEdit
v5 and v6.