### PR TITLE
Fix to transfer inventory from old Storage Minecart to new one. Fixes #326

### DIFF
--- a/src/main/java/com/onarandombox/MultiversePortals/listeners/MVPVehicleListener.java
+++ b/src/main/java/com/onarandombox/MultiversePortals/listeners/MVPVehicleListener.java
@@ -16,6 +16,7 @@ import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Vehicle;
 import org.bukkit.entity.minecart.StorageMinecart; 
+import org.bukkit.entity.minecart.HopperMinecart;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.vehicle.VehicleMoveEvent;
@@ -87,7 +88,7 @@ public class MVPVehicleListener implements Listener {
                 Vehicle newVehicle = target.getWorld().spawn(target, event.getVehicle().getClass());
 		
 		// Gets inventory from old Cart
-		if (event.getVehicle() instanceof StorageMinecart) {
+		if (event.getVehicle() instanceof StorageMinecart || event.getVehicle() instanceof HopperMinecart) {
 		ItemStack[] inv = ((InventoryHolder) event.getVehicle()).getInventory().getContents();
 		
 		// Fills Inventory to new Cart

--- a/src/main/java/com/onarandombox/MultiversePortals/listeners/MVPVehicleListener.java
+++ b/src/main/java/com/onarandombox/MultiversePortals/listeners/MVPVehicleListener.java
@@ -12,12 +12,16 @@ import java.util.Date;
 import com.onarandombox.MultiversePortals.enums.MoveType;
 import org.bukkit.Location;
 import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;  
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Vehicle;
+import org.bukkit.entity.minecart.StorageMinecart; 
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.vehicle.VehicleMoveEvent;
 import org.bukkit.util.Vector;
+import org.bukkit.inventory.InventoryHolder; 
+import org.bukkit.inventory.ItemStack; 
 
 import com.onarandombox.MultiverseCore.api.MVDestination;
 import com.onarandombox.MultiverseCore.destination.InvalidDestination;
@@ -78,8 +82,23 @@ public class MVPVehicleListener implements Listener {
 
                 Entity formerPassenger = event.getVehicle().getPassenger();
                 event.getVehicle().eject();
-
+		
+		
+		
+			
+		// Spawns new Minecart at Location
                 Vehicle newVehicle = target.getWorld().spawn(target, event.getVehicle().getClass());
+		
+
+		// Gets inventory from old Cart
+		if (event.getVehicle() instanceof StorageMinecart) {
+		ItemStack[] inv = ((InventoryHolder) event.getVehicle()).getInventory().getContents();
+		
+		// Fills Inventory to new Cart
+		
+	        InventoryHolder smc = (InventoryHolder) newVehicle; 
+	        smc.getInventory().setContents(inv); 		
+		}
 
                 if (formerPassenger != null) {
                     formerPassenger.teleport(target);
@@ -89,6 +108,7 @@ public class MVPVehicleListener implements Listener {
                 this.setVehicleVelocity(vehicleVec, dest, newVehicle);
 
                 // remove the old one
+		
                 event.getVehicle().remove();
             }
         }

--- a/src/main/java/com/onarandombox/MultiversePortals/listeners/MVPVehicleListener.java
+++ b/src/main/java/com/onarandombox/MultiversePortals/listeners/MVPVehicleListener.java
@@ -83,19 +83,14 @@ public class MVPVehicleListener implements Listener {
                 Entity formerPassenger = event.getVehicle().getPassenger();
                 event.getVehicle().eject();
 		
-		
-		
-			
 		// Spawns new Minecart at Location
                 Vehicle newVehicle = target.getWorld().spawn(target, event.getVehicle().getClass());
 		
-
 		// Gets inventory from old Cart
 		if (event.getVehicle() instanceof StorageMinecart) {
 		ItemStack[] inv = ((InventoryHolder) event.getVehicle()).getInventory().getContents();
 		
 		// Fills Inventory to new Cart
-		
 	        InventoryHolder smc = (InventoryHolder) newVehicle; 
 	        smc.getInventory().setContents(inv); 		
 		}
@@ -107,8 +102,7 @@ public class MVPVehicleListener implements Listener {
 
                 this.setVehicleVelocity(vehicleVec, dest, newVehicle);
 
-                // remove the old one
-		
+                // remove the old minecart
                 event.getVehicle().remove();
             }
         }

--- a/src/main/java/com/onarandombox/MultiversePortals/listeners/MVPVehicleListener.java
+++ b/src/main/java/com/onarandombox/MultiversePortals/listeners/MVPVehicleListener.java
@@ -88,7 +88,7 @@ public class MVPVehicleListener implements Listener {
                 Vehicle newVehicle = target.getWorld().spawn(target, event.getVehicle().getClass());
 		
 		// Gets inventory from old Cart
-		if (event.getVehicle() instanceof StorageMinecart || event.getVehicle() instanceof HopperMinecart) {
+		if (event.getVehicle() instanceof InventoryHolder) {
 		ItemStack[] inv = ((InventoryHolder) event.getVehicle()).getInventory().getContents();
 		
 		// Fills Inventory to new Cart


### PR DESCRIPTION
Fixes the Problem that Items get destroyed when Storage or Hopper Minecarts go through a Portal.
