### PR TITLE
Add support for new 1.15.1 PlayerPortalEvent api

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -160,7 +160,7 @@
         <dependency>
             <groupId>org.bukkit</groupId>
             <artifactId>bukkit</artifactId>
-            <version>1.13.2-R0.1-SNAPSHOT</version>
+            <version>1.15.1-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <!-- Start of Multiverse Core Dependency -->

--- a/src/main/java/com/onarandombox/MultiversePortals/listeners/MVPTravelAgent.java
+++ b/src/main/java/com/onarandombox/MultiversePortals/listeners/MVPTravelAgent.java
@@ -16,11 +16,22 @@ class MVPTravelAgent extends MVTravelAgent {
     }
 
     void setPortalEventTravelAgent(PlayerPortalEvent event) {
+        boolean error = false;
         try {
             Class.forName("org.bukkit.TravelAgent");
             new BukkitTravelAgent(this).setPortalEventTravelAgent(event);
         } catch (ClassNotFoundException ignore) {
-            core.log(Level.FINE, "TravelAgent not available for PlayerPortalEvent for " + player.getName());
+            error = true;
+        }
+        try {
+            event.setCanCreatePortal(false);
+            event.setCreationRadius(0);
+            event.setSearchRadius(0);
+        } catch (NoSuchMethodError ignore) {
+            error = true;
+        }
+        if (error) {
+            core.log(Level.FINE, "Neither TravelAgent nor portal creation/search methods available for PlayerPortalEvent for " + player.getName());
         }
     }
 }


### PR DESCRIPTION
This adds support for the new additions to the PlayerPortalEvent which re-introduce some of the settings from the old and removed TravelAgent API. It mirrors the values used in the BukkitTravelAgent class (0 radius and no portal creation).