### PR TITLE
mvp list: print one portal per line; sort alphabetically

### DIFF
--- a/src/main/java/com/onarandombox/MultiversePortals/commands/ListCommand.java
+++ b/src/main/java/com/onarandombox/MultiversePortals/commands/ListCommand.java
@@ -75,12 +75,19 @@ public class ListCommand extends PortalCommand {
 
     private List<String> getFilteredPortals(CommandSender sender, MultiverseWorld world, String filter) {
         List<String> portals_filtered = new ArrayList<>();
+        List<MVPortal> portals;
 
         if (filter == null) {
             filter = "";
         }
 
-        for (MVPortal p : (world == null) ? this.plugin.getPortalManager().getPortals(sender) : this.plugin.getPortalManager().getPortals(sender, world)) {
+        if (world == null) {
+            portals = this.plugin.getPortalManager().getPortals(sender);
+        } else {
+            portals = this.plugin.getPortalManager().getPortals(sender, world);
+        }
+
+        for (MVPortal p : portals) {
             if (p.getName().matches("(i?).*" + filter + ".*")) {
                 portals_filtered.add(p.getName());
             }

--- a/src/main/java/com/onarandombox/MultiversePortals/commands/ListCommand.java
+++ b/src/main/java/com/onarandombox/MultiversePortals/commands/ListCommand.java
@@ -8,6 +8,8 @@
 package com.onarandombox.MultiversePortals.commands;
 
 import java.util.List;
+import java.util.ArrayList;
+import java.util.Comparator;
 
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
@@ -58,33 +60,33 @@ public class ListCommand extends PortalCommand {
             titleString += ChatColor.GOLD + " [" + filter + "]";
         }
         sender.sendMessage(ChatColor.AQUA + "--- " + titleString + ChatColor.AQUA + " ---");
-        sender.sendMessage(getPortals(sender, world, filter));
 
+        boolean altColor = false;
+        for (String s : getFilteredPortals(sender, world, filter)) {
+            if (altColor) {
+                sender.sendMessage(ChatColor.YELLOW + s);
+                altColor = false;
+            } else {
+                sender.sendMessage(ChatColor.WHITE + s);
+                altColor = true;
+            }
+        }
     }
 
-    private String getPortals(CommandSender sender, MultiverseWorld world, String filter) {
-        String portals = "";
+    private List<String> getFilteredPortals(CommandSender sender, MultiverseWorld world, String filter) {
+        List<String> portals_filtered = new ArrayList<>();
+
         if (filter == null) {
             filter = "";
         }
-        boolean altColor = false;
+
         for (MVPortal p : (world == null) ? this.plugin.getPortalManager().getPortals(sender) : this.plugin.getPortalManager().getPortals(sender, world)) {
             if (p.getName().matches("(i?).*" + filter + ".*")) {
-                if (altColor) {
-                    portals += ChatColor.YELLOW;
-                    altColor = false;
-                } else {
-                    portals += ChatColor.WHITE;
-                    altColor = true;
-                }
-
-                portals += p.getName() + " ";
+                portals_filtered.add(p.getName());
             }
+        }
 
-        }
-        if (portals.length() > 2) {
-            portals = portals.substring(0, portals.length() - 1);
-        }
-        return portals;
+        portals_filtered.sort(Comparator.comparing(String::toString));
+        return portals_filtered;
     }
 }

--- a/src/main/java/com/onarandombox/MultiversePortals/commands/ListCommand.java
+++ b/src/main/java/com/onarandombox/MultiversePortals/commands/ListCommand.java
@@ -88,8 +88,9 @@ public class ListCommand extends PortalCommand {
         }
 
         for (MVPortal p : portals) {
-            if (p.getName().matches("(i?).*" + filter + ".*")) {
-                portals_filtered.add(p.getName());
+            String name = p.getName();
+            if (name.matches("(i?).*" + filter + ".*")) {
+                portals_filtered.add(name);
             }
         }
 


### PR DESCRIPTION
Hello,

I found that `mvp list` was not super useful in space-delimited, wrap-around form. So here's a patch that makes each portal show up on its own line with some optional refactor patches. Each commit compiles, and I tested the output in both 

On a related note, the docs don't show the `[FILTER]` option in https://github.com/Multiverse/Multiverse-Core/wiki/Command-Reference-(Portals)#list. I'm not sure if I'm able to edit that or not, but I would be happy to.

See https://github.com/Multiverse/Multiverse-Portals/blob/c189f2d3fc726263f72bf41f60cff1fbe1772c03/src/main/java/com/onarandombox/MultiversePortals/commands/ListCommand.java#L25.


