### PR TITLE
Remove old build instructions from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,3 @@
-# Building
-
-To build this project, the Bukkit/CraftBukkit dependencies must be obtained else-where.
-
-See http://www.spigotmc.org/threads/bukkit-craftbukkit-spigot-1-8.36598/ for details.
-
-Once you successfully have compiled Bukkit and CraftBukkit, define the environment variable SPIGOT_BASE to the location of the BuildTools.jar, and compile Multiverse-Portals.
-
 # Copyright Notice
 
 Copyright (c) 2011, The Multiverse Team All rights reserved.


### PR DESCRIPTION
It appears that these instructions are stale. I was able to build things just fine with Maven without manually installing any Spigot/Bukkit jars.