### PR TITLE
Fix NPE in extractPortalName

### DIFF
--- a/src/main/java/com/onarandombox/MultiversePortals/commands/ModifyCommand.java
+++ b/src/main/java/com/onarandombox/MultiversePortals/commands/ModifyCommand.java
@@ -166,11 +166,18 @@ public class ModifyCommand extends PortalCommand {
         if (!args.contains("-p")) {
             return null;
         }
+
         int index = args.indexOf("-p");
+
         // Now we remove the -p
         args.remove(index);
-        // Now we remove and return the portalname
-        return args.remove(index);
+
+        // Now we remove and return the portalname if present
+        if (index < args.size()) {
+            return args.remove(index);
+        }
+
+        return null;
     }
 
     protected static boolean validateAction(String property) {


### PR DESCRIPTION
This PR fixes an NPE in the `extractPortalName` method from the `ModifyCommand` class. This fixes #171.

Now, if a user doesn't specify the portal name, they'll get a message telling them that it's missing.