### PR TITLE
Fix Physics With nether_portal Block

### DIFF
--- a/src/main/java/com/onarandombox/MultiversePortals/utils/PortalFiller.java
+++ b/src/main/java/com/onarandombox/MultiversePortals/utils/PortalFiller.java
@@ -62,7 +62,9 @@ public class PortalFiller {
         if (isValidPortalRegion(newLoc.getLocation(), type)) {
             // we need to check if the fill material is nether_portal so we can rotate it if necessary
             if (type == Material.NETHER_PORTAL) {
-                // for now we won't use physics because it causes errors
+                // we won't use physics with nether_portal blocks because we cancel
+                // the BlockPhysicsEvent to prevent accidentally breaking the blocks.
+                // if we were to use physics, errors would be thrown upon breaking the portal blocks.
                 boolean usePhysics = false;
                 newLoc.setType(type, usePhysics);
                 if (useX == 0) {


### PR DESCRIPTION
This PR fixes the issue where the console would spew errors when the `nether_portal` blocks were removed when placed with physics enabled. It seems the issue was our event handler cancelling the physics event. I tested this change on 1.16.3 and found no regressions.