### PR TITLE
Register and Unregister Event Handlers as Necessary

### DIFF
--- a/src/main/java/com/onarandombox/MultiversePortals/MultiversePortals.java
+++ b/src/main/java/com/onarandombox/MultiversePortals/MultiversePortals.java
@@ -416,8 +416,14 @@ public class MultiversePortals extends JavaPlugin implements MVPlugin {
     }
 
     public void reloadConfigs() {
-        this.portalManager.removeAll(false);
-        this.loadPortals();
+        this.reloadConfigs(true);
+    }
+
+    public void reloadConfigs(boolean reloadPortals) {
+        if (reloadPortals) {
+            this.portalManager.removeAll(false);
+            this.loadPortals();
+        }
 
         PluginManager pm = this.getServer().getPluginManager();
         boolean previousTeleportVehicles = MultiversePortals.TeleportVehicles;

--- a/src/main/java/com/onarandombox/MultiversePortals/MultiversePortals.java
+++ b/src/main/java/com/onarandombox/MultiversePortals/MultiversePortals.java
@@ -22,7 +22,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.logging.Level;
-import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 import com.dumptruckman.minecraft.util.Logging;
@@ -40,8 +39,11 @@ import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockFromToEvent;
+import org.bukkit.event.player.PlayerMoveEvent;
 import org.bukkit.event.server.PluginDisableEvent;
 import org.bukkit.event.server.PluginEnableEvent;
+import org.bukkit.event.vehicle.VehicleMoveEvent;
 import org.bukkit.permissions.Permission;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.PluginManager;
@@ -154,7 +156,6 @@ public class MultiversePortals extends JavaPlugin implements MVPlugin {
         PlayerListenerHelper playerListenerHelper = new PlayerListenerHelper(this);
         MVPPlayerListener playerListener = new MVPPlayerListener(this, playerListenerHelper);
         MVPBlockListener blockListener = new MVPBlockListener(this);
-        MVPVehicleListener vehicleListener = new MVPVehicleListener(this);
         MVPCoreListener coreListener = new MVPCoreListener(this);
 
         // Register our listeners with the Bukkit Server
@@ -163,7 +164,7 @@ public class MultiversePortals extends JavaPlugin implements MVPlugin {
         pm.registerEvents(playerListener, this);
         pm.registerEvents(blockListener, this);
         if (MultiversePortals.TeleportVehicles) {
-            pm.registerEvents(vehicleListener, this);
+            pm.registerEvents(new MVPVehicleListener(this), this);
         }
         if (MultiversePortals.UseOnMove) {
             pm.registerEvents(new MVPPlayerMoveListener(this, playerListenerHelper), this);
@@ -417,7 +418,29 @@ public class MultiversePortals extends JavaPlugin implements MVPlugin {
     public void reloadConfigs() {
         this.portalManager.removeAll(false);
         this.loadPortals();
+
+        PluginManager pm = this.getServer().getPluginManager();
+        boolean previousTeleportVehicles = MultiversePortals.TeleportVehicles;
+        boolean previousUseOnMove = MultiversePortals.UseOnMove;
+
         this.loadConfig();
+
+        if (MultiversePortals.TeleportVehicles != previousTeleportVehicles) {
+            if (MultiversePortals.TeleportVehicles) {
+                pm.registerEvents(new MVPVehicleListener(this), this);
+            } else {
+                VehicleMoveEvent.getHandlerList().unregister(this);
+            }
+        }
+
+        if (MultiversePortals.UseOnMove != previousUseOnMove) {
+            if (MultiversePortals.UseOnMove) {
+                pm.registerEvents(new MVPPlayerMoveListener(this, new PlayerListenerHelper(this)), this);
+            } else {
+                BlockFromToEvent.getHandlerList().unregister(this);
+                PlayerMoveEvent.getHandlerList().unregister(this);
+            }
+        }
     }
 
     /**

--- a/src/main/java/com/onarandombox/MultiversePortals/commands/ConfigCommand.java
+++ b/src/main/java/com/onarandombox/MultiversePortals/commands/ConfigCommand.java
@@ -91,7 +91,7 @@ public class ConfigCommand extends PortalCommand {
         }
         if (this.plugin.saveMainConfig()) {
             sender.sendMessage(ChatColor.GREEN + "SUCCESS!" + ChatColor.WHITE + " Values were updated successfully!");
-            this.plugin.loadConfig();
+            this.plugin.reloadConfigs(false);
         } else {
             sender.sendMessage(ChatColor.RED + "FAIL!" + ChatColor.WHITE + " Check your console for details!");
         }

--- a/src/main/java/com/onarandombox/MultiversePortals/listeners/MVPBlockListener.java
+++ b/src/main/java/com/onarandombox/MultiversePortals/listeners/MVPBlockListener.java
@@ -9,12 +9,9 @@ package com.onarandombox.MultiversePortals.listeners;
 
 import org.bukkit.Material;
 import org.bukkit.event.EventHandler;
-import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
-import org.bukkit.event.block.BlockFromToEvent;
 import org.bukkit.event.block.BlockPhysicsEvent;
 
-import com.onarandombox.MultiversePortals.MVPortal;
 import com.onarandombox.MultiversePortals.MultiversePortals;
 import com.onarandombox.MultiversePortals.utils.PortalManager;
 
@@ -23,34 +20,6 @@ public class MVPBlockListener implements Listener {
 
     public MVPBlockListener(MultiversePortals plugin) {
         this.plugin = plugin;
-    }
-
-    @EventHandler(priority = EventPriority.LOW)
-    public void blockFromTo(BlockFromToEvent event) {
-        // Always check if the event has been canceled by someone else.
-        if(event.isCancelled()) {
-            return;
-        }
-        // If UseOnMove is false, every usable portal will be lit. Since water
-        // and lava don't flow into portal blocks, no special action is
-        // required -- we can simply skip the rest of this function.
-        if (!MultiversePortals.UseOnMove) {
-            return;
-        }
-
-        // The to block should never be null, but apparently it is sometimes...
-        if (event.getBlock() == null || event.getToBlock() == null)
-            return;
-
-        // If lava/something else is trying to flow in...
-        if (plugin.getPortalManager().isPortal(event.getToBlock().getLocation())) {
-            event.setCancelled(true);
-            return;
-        }
-        // If something is trying to flow out, stop that too.
-        if (plugin.getPortalManager().isPortal(event.getBlock().getLocation())) {
-            event.setCancelled(true);
-        }
     }
 
     @EventHandler

--- a/src/main/java/com/onarandombox/MultiversePortals/listeners/MVPPlayerMoveListener.java
+++ b/src/main/java/com/onarandombox/MultiversePortals/listeners/MVPPlayerMoveListener.java
@@ -44,16 +44,11 @@ public class MVPPlayerMoveListener implements Listener {
         if(event.isCancelled()) {
             return;
         }
-        // If UseOnMove is false, every usable portal will be lit. Since water
-        // and lava don't flow into portal blocks, no special action is
-        // required -- we can simply skip the rest of this function.
-        if (!MultiversePortals.UseOnMove) {
-            return;
-        }
 
         // The to block should never be null, but apparently it is sometimes...
-        if (event.getBlock() == null || event.getToBlock() == null)
+        if (event.getBlock() == null || event.getToBlock() == null) {
             return;
+        }
 
         // If lava/something else is trying to flow in...
         if (plugin.getPortalManager().isPortal(event.getToBlock().getLocation())) {
@@ -68,14 +63,13 @@ public class MVPPlayerMoveListener implements Listener {
 
     @EventHandler(priority = EventPriority.LOW)
     public void playerMove(PlayerMoveEvent event) {
-        if (event.isCancelled() || !MultiversePortals.UseOnMove) {
+        if (event.isCancelled()) {
             return;
         }
         Player p = event.getPlayer(); // Grab Player
         Location loc = p.getLocation(); // Grab Location
-        /**
-         * Check the Player has actually moved a block to prevent unneeded calculations... This is to prevent huge performance drops on high player count servers.
-         */
+
+        // Check the Player has actually moved a block to prevent unneeded calculations... This is to prevent huge performance drops on high player count servers.
         PortalPlayerSession ps = this.plugin.getPortalSession(event.getPlayer());
         ps.setStaleLocation(loc, MoveType.PLAYER_MOVE);
 

--- a/src/main/java/com/onarandombox/MultiversePortals/listeners/MVPPlayerMoveListener.java
+++ b/src/main/java/com/onarandombox/MultiversePortals/listeners/MVPPlayerMoveListener.java
@@ -25,6 +25,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockFromToEvent;
 import org.bukkit.event.player.PlayerMoveEvent;
 
 public class MVPPlayerMoveListener implements Listener {
@@ -35,6 +36,34 @@ public class MVPPlayerMoveListener implements Listener {
     public MVPPlayerMoveListener(MultiversePortals plugin, PlayerListenerHelper helper) {
         this.plugin = plugin;
         this.helper = helper;
+    }
+
+    @EventHandler(priority = EventPriority.LOW)
+    public void blockFromTo(BlockFromToEvent event) {
+        // Always check if the event has been canceled by someone else.
+        if(event.isCancelled()) {
+            return;
+        }
+        // If UseOnMove is false, every usable portal will be lit. Since water
+        // and lava don't flow into portal blocks, no special action is
+        // required -- we can simply skip the rest of this function.
+        if (!MultiversePortals.UseOnMove) {
+            return;
+        }
+
+        // The to block should never be null, but apparently it is sometimes...
+        if (event.getBlock() == null || event.getToBlock() == null)
+            return;
+
+        // If lava/something else is trying to flow in...
+        if (plugin.getPortalManager().isPortal(event.getToBlock().getLocation())) {
+            event.setCancelled(true);
+            return;
+        }
+        // If something is trying to flow out, stop that too.
+        if (plugin.getPortalManager().isPortal(event.getBlock().getLocation())) {
+            event.setCancelled(true);
+        }
     }
 
     @EventHandler(priority = EventPriority.LOW)


### PR DESCRIPTION
This PR unregisters some event handlers when they aren't needed (on config reload), hopefully this makes MV Portals more efficient. This PR is only safe to be merged after #582 since I didn't handle the removed event listener in this PR.