### PR TITLE
Fix Legacy Portal Detection

### DIFF
--- a/src/main/java/com/onarandombox/MultiversePortals/MVPortal.java
+++ b/src/main/java/com/onarandombox/MultiversePortals/MVPortal.java
@@ -303,6 +303,19 @@ public class MVPortal {
         return this.location;
     }
 
+    public Material getFillMaterial() throws IllegalStateException {
+        if (!this.location.isValidLocation()) {
+            throw new IllegalStateException();
+        }
+
+        return new Vector().copy(this.location.getMinimum()).add(this.location.getMaximum()).multiply(0.5)
+                .toLocation(this.location.getMVWorld().getCBWorld()).getBlock().getType();
+    }
+
+    public boolean isLegacyPortal() throws IllegalStateException {
+        return this.getFillMaterial() != Material.NETHER_PORTAL;
+    }
+
     public boolean playerCanEnterPortal(Player player) {
         return (this.plugin.getCore().getMVPerms().hasPermission(player, this.permission.getName(), true));
     }

--- a/src/main/java/com/onarandombox/MultiversePortals/enums/PortalType.java
+++ b/src/main/java/com/onarandombox/MultiversePortals/enums/PortalType.java
@@ -14,4 +14,7 @@ package com.onarandombox.MultiversePortals.enums;
  * If Normal, a Nether style portal (with purple goo) was used.
  *
  */
-public enum PortalType { Legacy, Normal }
+public enum PortalType {
+    LEGACY,
+    NORMAL
+}

--- a/src/main/java/com/onarandombox/MultiversePortals/event/MVPortalEvent.java
+++ b/src/main/java/com/onarandombox/MultiversePortals/event/MVPortalEvent.java
@@ -90,13 +90,15 @@ public class MVPortalEvent extends Event implements Cancellable {
      *
      * This will be Legacy for MV1 style portals and Normal for Portals that use the swirly purple goo.
      *
-     * @return A {@link PortalType}
+     * @throws IllegalStateException if the portal has an invalid location.
+     * @return A {@link PortalType}.
      */
-    public PortalType getPortalType() {
-        if (this.travelAgent == null) {
-            return PortalType.Legacy;
+    public PortalType getPortalType() throws IllegalStateException {
+        if (this.sendingPortal.isLegacyPortal()) {
+            return PortalType.LEGACY;
         }
-        return PortalType.Legacy;
+
+        return PortalType.NORMAL;
     }
 
     /**

--- a/src/main/java/com/onarandombox/MultiversePortals/listeners/MVPPlayerMoveListener.java
+++ b/src/main/java/com/onarandombox/MultiversePortals/listeners/MVPPlayerMoveListener.java
@@ -55,10 +55,10 @@ public class MVPPlayerMoveListener implements Listener {
             return;
         }
         MVPortal portal = ps.getStandingInPortal();
-        // If the portal is not null
-        // AND if we did not show debug info, do the stuff
-        // The debug is meant to toggle.
-        if (portal != null && ps.doTeleportPlayer(MoveType.PLAYER_MOVE) && !ps.showDebugInfo()) {
+        // If the portal is not null, and it's a legacy portal,
+        // and if we didn't show debug info, do the stuff.
+        // (the debug is meant to toggle)
+        if (portal != null && portal.isLegacyPortal() && ps.doTeleportPlayer(MoveType.PLAYER_MOVE) && !ps.showDebugInfo()) {
             MVDestination d = portal.getDestination();
             if (d == null) {
                 return;


### PR DESCRIPTION
This PR fixes legacy portal detection. Although, it seems it wasn't used anywhere, it's important that it works properly for anyone who wants to use the API. I also made it so that the Player Move event handler only handles legacy portals, but this exposed a bug. It seems the player portal event handler doesn't work properly for normal portals. I tested this on 1.16.3.