### PR TITLE
Add NPE check on location when teleporting

### DIFF
--- a/src/main/java/com/onarandombox/MultiversePortals/listeners/MVPPlayerListener.java
+++ b/src/main/java/com/onarandombox/MultiversePortals/listeners/MVPPlayerListener.java
@@ -239,6 +239,7 @@ public class MVPPlayerListener implements Listener {
 
                 Location destLocation = portalDest.getLocation(event.getPlayer());
                 if (destLocation == null) {
+                    event.setCancelled(true);
                     return;
                 }
 

--- a/src/main/java/com/onarandombox/MultiversePortals/listeners/MVPPlayerListener.java
+++ b/src/main/java/com/onarandombox/MultiversePortals/listeners/MVPPlayerListener.java
@@ -236,6 +236,12 @@ public class MVPPlayerListener implements Listener {
                     event.setCancelled(true);
                     return;
                 }
+
+                Location destLocation = portalDest.getLocation(event.getPlayer());
+                if (destLocation == null) {
+                    return;
+                }
+
                 PortalPlayerSession ps = this.plugin.getPortalSession(event.getPlayer());
                 if (portal.getHandlerScript() != null && !portal.getHandlerScript().isEmpty()) {
                     try {
@@ -262,7 +268,7 @@ public class MVPPlayerListener implements Listener {
                     return;
                 }
                 MVPTravelAgent agent = new MVPTravelAgent(this.plugin.getCore(), portalDest, event.getPlayer());
-                event.setTo(portalDest.getLocation(event.getPlayer()));
+                event.setTo(destLocation);
                 if (portalDest.useSafeTeleporter()) {
                     SafeTTeleporter teleporter = this.plugin.getCore().getSafeTTeleporter();
                     event.setTo(teleporter.getSafeLocation(event.getPlayer(), portalDest));

--- a/src/main/java/com/onarandombox/MultiversePortals/listeners/MVPPlayerMoveListener.java
+++ b/src/main/java/com/onarandombox/MultiversePortals/listeners/MVPPlayerMoveListener.java
@@ -21,7 +21,6 @@ import com.onarandombox.MultiversePortals.enums.MoveType;
 import com.onarandombox.MultiversePortals.event.MVPortalEvent;
 import org.bukkit.Location;
 import org.bukkit.Material;
-import org.bukkit.World;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -95,7 +94,9 @@ public class MVPPlayerMoveListener implements Listener {
             }
 
             Location destLocation = d.getLocation(p);
-            if (destLocation == null) return;
+            if (destLocation == null) {
+                return;
+            }
 
             MultiverseWorld world = this.plugin.getCore().getMVWorldManager().getMVWorld(destLocation.getWorld().getName());
             if (world == null) {

--- a/src/main/java/com/onarandombox/MultiversePortals/listeners/MVPPlayerMoveListener.java
+++ b/src/main/java/com/onarandombox/MultiversePortals/listeners/MVPPlayerMoveListener.java
@@ -21,6 +21,7 @@ import com.onarandombox.MultiversePortals.enums.MoveType;
 import com.onarandombox.MultiversePortals.event.MVPortalEvent;
 import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.World;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -93,7 +94,10 @@ public class MVPPlayerMoveListener implements Listener {
                 return;
             }
 
-            MultiverseWorld world = this.plugin.getCore().getMVWorldManager().getMVWorld(d.getLocation(p).getWorld().getName());
+            Location destLocation = d.getLocation(p);
+            if (destLocation == null) return;
+
+            MultiverseWorld world = this.plugin.getCore().getMVWorldManager().getMVWorld(destLocation.getWorld().getName());
             if (world == null) {
                 return;
             }


### PR DESCRIPTION
Fixes #593 

This fixes a null pointer exception when the location of a player's bed does not exist. This could occur from other destinations, but I haven't tested them on the unpatched version.