### PR TITLE
Clean up and fix cooldown message code.

### DIFF
--- a/src/main/java/com/onarandombox/MultiversePortals/PortalPlayerSession.java
+++ b/src/main/java/com/onarandombox/MultiversePortals/PortalPlayerSession.java
@@ -282,31 +282,31 @@ public class PortalPlayerSession {
         this.lastTeleportTime = date;
     }
 
-    public boolean allowTeleportViaCooldown(Date date) {
-        return (date.after(new Date(this.lastTeleportTime.getTime() + this.plugin.getCooldownTime())));
-    }
-
-    public String getFriendlyRemainingTimeMessage() {
-        String remaining = "There is a portal " + ChatColor.AQUA + "cooldown" + ChatColor.WHITE + " in effect. Please try again in " + ChatColor.GOLD
-        + Integer.toString((int) this.getRemainingCooldown() / 1000) + "s.";
-        int time = (int) this.getRemainingCooldown() / 1000;
-        // Account for the fact that 0 seconds means 1
-        time++;
-        if (time <= 0) {
-            remaining += "< 1s" + ChatColor.WHITE + ".";
+    /**
+     * Check if the teleport cooldown will finish before the given time is
+     * reached. If so, return the remaining cooldown time in ms. If not, return 0.
+     */
+    public long getRemainingTeleportCooldown(Date time) {
+        long cooldownEndMs = this.lastTeleportTime.getTime() + this.plugin.getCooldownTime();
+        long timeMs = time.getTime();
+        if (cooldownEndMs > timeMs) {
+            return cooldownEndMs - timeMs;
         } else {
-            remaining += time + "s" + ChatColor.WHITE + ".";
+            return 0;
         }
-        return remaining;
     }
 
-    public long getRemainingCooldown() {
-        //Calculate the remaining cooldown period
-        long remainingcooldown = (this.plugin.getCooldownTime() - ((new Date()).getTime() - this.lastTeleportTime.getTime()));
-        if (remainingcooldown < 0) {
-            remainingcooldown = 0;
-        }
-        return remainingcooldown;
+    public String getCooldownMessage(long cooldownMs) {
+        String remaining = "There is a portal " + ChatColor.AQUA + "cooldown " +
+            ChatColor.WHITE + "in effect. Please try again in " +
+            ChatColor.GOLD;
 
+        if (cooldownMs < 1000) {
+            remaining += "1 s";
+        } else {
+            remaining += (cooldownMs/1000) + " s";
+        }
+        remaining += ChatColor.WHITE + ".";
+        return remaining;
     }
 }

--- a/src/main/java/com/onarandombox/MultiversePortals/listeners/MVPPlayerListener.java
+++ b/src/main/java/com/onarandombox/MultiversePortals/listeners/MVPPlayerListener.java
@@ -232,8 +232,9 @@ public class MVPPlayerListener implements Listener {
                         // Portal not handled by script
                     }
                 }
-                if (!ps.allowTeleportViaCooldown(new Date())) {
-                    event.getPlayer().sendMessage(ps.getFriendlyRemainingTimeMessage());
+                long cooldownMs = ps.getRemainingTeleportCooldown(new Date());
+                if (cooldownMs > 0) {
+                    event.getPlayer().sendMessage(ps.getCooldownMessage(cooldownMs));
                     event.setCancelled(true);
                     return;
                 }

--- a/src/main/java/com/onarandombox/MultiversePortals/listeners/MVPPlayerMoveListener.java
+++ b/src/main/java/com/onarandombox/MultiversePortals/listeners/MVPPlayerMoveListener.java
@@ -89,8 +89,9 @@ public class MVPPlayerMoveListener implements Listener {
                     // Portal not handled by script
                 }
             }
-            if (!ps.allowTeleportViaCooldown(new Date())) {
-                p.sendMessage(ps.getFriendlyRemainingTimeMessage());
+            long cooldownMs = ps.getRemainingTeleportCooldown(new Date());
+            if (cooldownMs > 0) {
+                p.sendMessage(ps.getCooldownMessage(cooldownMs));
                 return;
             }
             // If they're using Access and they don't have permission and they're NOT excempt, return, they're not allowed to tp.

--- a/src/main/java/com/onarandombox/MultiversePortals/listeners/MVPVehicleListener.java
+++ b/src/main/java/com/onarandombox/MultiversePortals/listeners/MVPVehicleListener.java
@@ -101,8 +101,9 @@ public class MVPVehicleListener implements Listener {
         // AND if we did not show debug info, do the stuff
         // The debug is meant to toggle.
         if (portal != null && ps.doTeleportPlayer(MoveType.VEHICLE_MOVE) && !ps.showDebugInfo()) {
-            if (!ps.allowTeleportViaCooldown(new Date())) {
-                p.sendMessage(ps.getFriendlyRemainingTimeMessage());
+            long cooldownMs = ps.getRemainingTeleportCooldown(new Date());
+            if (cooldownMs > 0) {
+                p.sendMessage(ps.getCooldownMessage(cooldownMs));
                 return false;
             }
             // TODO: Money


### PR DESCRIPTION
>There were too many levels of indirection, leading to multiple sample
times and wasteful date object instantiations.
>
>Fixes #444

This PR is the same as the now closed (and un-openable) #538. The reason it can't be opened is because the base branch was deleted, and GitHub cannot reopen PRs once that has happened.