### PR TITLE
Clean up and fix cooldown checking and message code.

### DIFF
--- a/src/main/java/com/onarandombox/MultiversePortals/PortalPlayerSession.java
+++ b/src/main/java/com/onarandombox/MultiversePortals/PortalPlayerSession.java
@@ -283,30 +283,59 @@ public class PortalPlayerSession {
     }
 
     /**
-     * Check if the teleport cooldown will finish before the given time is
-     * reached. If so, return the remaining cooldown time in ms. If not, return 0.
+     * Checks if the teleport cooldown is still in effect. If it is, a message is sent
+     * to the player informing them.
+     *
+     * @return True if the teleport cooldown is still in effect, false otherwise.
      */
-    public long getRemainingTeleportCooldown(Date time) {
-        long cooldownEndMs = this.lastTeleportTime.getTime() + this.plugin.getCooldownTime();
-        long timeMs = time.getTime();
-        if (cooldownEndMs > timeMs) {
-            return cooldownEndMs - timeMs;
-        } else {
-            return 0;
+    public boolean checkAndSendCooldownMessage() {
+        long cooldownMs = this.getRemainingTeleportCooldown();
+        if (cooldownMs > 0) {
+            this.getPlayerFromName().sendMessage(this.getCooldownMessage(cooldownMs));
+            return true;
         }
+
+        return false;
     }
 
-    public String getCooldownMessage(long cooldownMs) {
-        String remaining = "There is a portal " + ChatColor.AQUA + "cooldown " +
-            ChatColor.WHITE + "in effect. Please try again in " +
-            ChatColor.GOLD;
+    /**
+     * Get the remaining teleport cooldown time in milliseconds.
+     * If the value returned is not positive, the cooldown is no longer in effect.
+     *
+     * @return The remaining teleport cooldown time in milliseconds. Note that a
+     *         negative value may be returned if the cooldown is no longer in effect.
+     */
+    private long getRemainingTeleportCooldown() {
+        long cooldownEndMs = this.lastTeleportTime.getTime() + this.plugin.getCooldownTime();
+        long timeMs = (new Date()).getTime();
+        return cooldownEndMs - timeMs;
+    }
 
+    /**
+     * Constructs a message informing a player about the
+     * remaining cooldown time.
+     *
+     * @param cooldownMs The cooldown time in milliseconds.
+     * @return           A message to be sent to a player, informing them about the remaining cooldown time.
+     */
+    private String getCooldownMessage(long cooldownMs) {
+        return "There is a portal " + ChatColor.AQUA + "cooldown "
+                + ChatColor.WHITE + "in effect. Please try again in "
+                + ChatColor.GOLD + this.formatCooldownTime(cooldownMs)
+                + ChatColor.WHITE + ".";
+    }
+
+    /**
+     * Converts a long representing a time in milliseconds to a human-readable String.
+     *
+     * @param cooldownMs Time in milliseconds.
+     * @return Human-readable String with the given time in seconds.
+     */
+    private String formatCooldownTime(long cooldownMs) {
         if (cooldownMs < 1000) {
-            remaining += "1 s";
-        } else {
-            remaining += (cooldownMs/1000) + " s";
+            return "1s";
         }
-        remaining += ChatColor.WHITE + ".";
-        return remaining;
+
+        return (cooldownMs / 1000) + "s";
     }
 }

--- a/src/main/java/com/onarandombox/MultiversePortals/PortalPlayerSession.java
+++ b/src/main/java/com/onarandombox/MultiversePortals/PortalPlayerSession.java
@@ -282,31 +282,31 @@ public class PortalPlayerSession {
         this.lastTeleportTime = date;
     }
 
-    public boolean allowTeleportViaCooldown(Date date) {
-        return (date.after(new Date(this.lastTeleportTime.getTime() + this.plugin.getCooldownTime())));
-    }
-
-    public String getFriendlyRemainingTimeMessage() {
-        String remaining = "There is a portal " + ChatColor.AQUA + "cooldown" + ChatColor.WHITE + " in effect. Please try again in " + ChatColor.GOLD
-        + Integer.toString((int) this.getRemainingCooldown() / 1000) + "s.";
-        int time = (int) this.getRemainingCooldown() / 1000;
-        // Account for the fact that 0 seconds means 1
-        time++;
-        if (time <= 0) {
-            remaining += "< 1s" + ChatColor.WHITE + ".";
+    /**
+     * Check if the teleport cooldown will finish before the given time is
+     * reached. If so, return the remaining cooldown time in ms. If not, return 0.
+     */
+    public long getRemainingTeleportCooldown(Date time) {
+        long cooldownEndMs = this.lastTeleportTime.getTime() + this.plugin.getCooldownTime();
+        long timeMs = time.getTime();
+        if (cooldownEndMs > timeMs) {
+            return cooldownEndMs - timeMs;
         } else {
-            remaining += time + "s" + ChatColor.WHITE + ".";
+            return 0;
         }
-        return remaining;
     }
 
-    public long getRemainingCooldown() {
-        //Calculate the remaining cooldown period
-        long remainingcooldown = (this.plugin.getCooldownTime() - ((new Date()).getTime() - this.lastTeleportTime.getTime()));
-        if (remainingcooldown < 0) {
-            remainingcooldown = 0;
-        }
-        return remainingcooldown;
+    public String getCooldownMessage(long cooldownMs) {
+        String remaining = "There is a portal " + ChatColor.AQUA + "cooldown " +
+            ChatColor.WHITE + "in effect. Please try again in " +
+            ChatColor.GOLD;
 
+        if (cooldownMs < 1000) {
+            remaining += "1 s";
+        } else {
+            remaining += (cooldownMs/1000) + " s";
+        }
+        remaining += ChatColor.WHITE + ".";
+        return remaining;
     }
 }

--- a/src/main/java/com/onarandombox/MultiversePortals/listeners/MVPPlayerListener.java
+++ b/src/main/java/com/onarandombox/MultiversePortals/listeners/MVPPlayerListener.java
@@ -249,9 +249,7 @@ public class MVPPlayerListener implements Listener {
                         // Portal not handled by script
                     }
                 }
-                long cooldownMs = ps.getRemainingTeleportCooldown(new Date());
-                if (cooldownMs > 0) {
-                    event.getPlayer().sendMessage(ps.getCooldownMessage(cooldownMs));
+                if (ps.checkAndSendCooldownMessage()) {
                     event.setCancelled(true);
                     return;
                 }

--- a/src/main/java/com/onarandombox/MultiversePortals/listeners/MVPPlayerListener.java
+++ b/src/main/java/com/onarandombox/MultiversePortals/listeners/MVPPlayerListener.java
@@ -249,8 +249,9 @@ public class MVPPlayerListener implements Listener {
                         // Portal not handled by script
                     }
                 }
-                if (!ps.allowTeleportViaCooldown(new Date())) {
-                    event.getPlayer().sendMessage(ps.getFriendlyRemainingTimeMessage());
+                long cooldownMs = ps.getRemainingTeleportCooldown(new Date());
+                if (cooldownMs > 0) {
+                    event.getPlayer().sendMessage(ps.getCooldownMessage(cooldownMs));
                     event.setCancelled(true);
                     return;
                 }

--- a/src/main/java/com/onarandombox/MultiversePortals/listeners/MVPPlayerMoveListener.java
+++ b/src/main/java/com/onarandombox/MultiversePortals/listeners/MVPPlayerMoveListener.java
@@ -116,9 +116,7 @@ public class MVPPlayerMoveListener implements Listener {
                     plugin.log(Level.WARNING, "Buscript wasn't initialized, so we can't use scripts!");
                 }
             }
-            long cooldownMs = ps.getRemainingTeleportCooldown(new Date());
-            if (cooldownMs > 0) {
-                p.sendMessage(ps.getCooldownMessage(cooldownMs));
+            if (ps.checkAndSendCooldownMessage()) {
                 return;
             }
             // If they're using Access and they don't have permission and they're NOT excempt, return, they're not allowed to tp.

--- a/src/main/java/com/onarandombox/MultiversePortals/listeners/MVPPlayerMoveListener.java
+++ b/src/main/java/com/onarandombox/MultiversePortals/listeners/MVPPlayerMoveListener.java
@@ -116,8 +116,9 @@ public class MVPPlayerMoveListener implements Listener {
                     plugin.log(Level.WARNING, "Buscript wasn't initialized, so we can't use scripts!");
                 }
             }
-            if (!ps.allowTeleportViaCooldown(new Date())) {
-                p.sendMessage(ps.getFriendlyRemainingTimeMessage());
+            long cooldownMs = ps.getRemainingTeleportCooldown(new Date());
+            if (cooldownMs > 0) {
+                p.sendMessage(ps.getCooldownMessage(cooldownMs));
                 return;
             }
             // If they're using Access and they don't have permission and they're NOT excempt, return, they're not allowed to tp.

--- a/src/main/java/com/onarandombox/MultiversePortals/listeners/MVPVehicleListener.java
+++ b/src/main/java/com/onarandombox/MultiversePortals/listeners/MVPVehicleListener.java
@@ -101,8 +101,9 @@ public class MVPVehicleListener implements Listener {
         // AND if we did not show debug info, do the stuff
         // The debug is meant to toggle.
         if (portal != null && ps.doTeleportPlayer(MoveType.VEHICLE_MOVE) && !ps.showDebugInfo()) {
-            if (!ps.allowTeleportViaCooldown(new Date())) {
-                p.sendMessage(ps.getFriendlyRemainingTimeMessage());
+            long cooldownMs = ps.getRemainingTeleportCooldown(new Date());
+            if (cooldownMs > 0) {
+                p.sendMessage(ps.getCooldownMessage(cooldownMs));
                 return false;
             }
             // TODO: Money

--- a/src/main/java/com/onarandombox/MultiversePortals/listeners/MVPVehicleListener.java
+++ b/src/main/java/com/onarandombox/MultiversePortals/listeners/MVPVehicleListener.java
@@ -101,9 +101,7 @@ public class MVPVehicleListener implements Listener {
         // AND if we did not show debug info, do the stuff
         // The debug is meant to toggle.
         if (portal != null && ps.doTeleportPlayer(MoveType.VEHICLE_MOVE) && !ps.showDebugInfo()) {
-            long cooldownMs = ps.getRemainingTeleportCooldown(new Date());
-            if (cooldownMs > 0) {
-                p.sendMessage(ps.getCooldownMessage(cooldownMs));
+            if (ps.checkAndSendCooldownMessage()) {
                 return false;
             }
             // TODO: Money


### PR DESCRIPTION
This PR includes the change made in #538, with some additional cleanup.

#538 fixed a few issues such as sending the cooldown twice, and enacting cooldown on the first time a player enters a nether-style portal. This PR does not include any additional fixes.

P.S. I tested this right before opening this PR, it's all working as expected :)