### PR TITLE
Some changes for better clarity of the list command

### DIFF
--- a/src/main/java/com/onarandombox/MultiversePortals/commands/ListCommand.java
+++ b/src/main/java/com/onarandombox/MultiversePortals/commands/ListCommand.java
@@ -96,17 +96,16 @@ public class ListCommand extends PortalCommand {
             String destination = "";
             if(p.getDestination() != null) {
                 destination = p.getDestination().toString();
-
                 MultiverseWorld destWorld = this.plugin.getCore().getMVWorldManager().getMVWorld(destination);
                 if (destWorld != null) {
                     destination = "(World) " + ChatColor.DARK_AQUA + destination;
                 } else {
                     String destType = destination.substring(0, 1);
                     if (destType.equals("p")) {
-                        destination = "(Portal) " + ChatColor.DARK_AQUA + p.getDestination().getName();
+                        String targetWorldName = plugin.getPortalManager().getPortal(p.getDestination().getName()).getWorld().getName();
+                        destination = "(Portal) " + ChatColor.DARK_AQUA + p.getDestination().getName() + ChatColor.GRAY + " (" + targetWorldName + ")";
                     }
                     if (destType.equals("e")) {
-                        //String destParts = p.getDestination().toString().substring(2, p.getDestination().toString().length()-1);
                         String destinationWorld = p.getDestination().toString().split(":")[1];
                         String destPart = p.getDestination().toString().split(":")[2];
                         String[] locParts = destPart.split(",");

--- a/src/main/java/com/onarandombox/MultiversePortals/commands/ListCommand.java
+++ b/src/main/java/com/onarandombox/MultiversePortals/commands/ListCommand.java
@@ -9,6 +9,7 @@ package com.onarandombox.MultiversePortals.commands;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
@@ -92,38 +93,40 @@ public class ListCommand extends PortalCommand {
         if (filter == null) {
             filter = "";
         }
-        for (MVPortal p : (world == null) ? this.plugin.getPortalManager().getPortals(sender) : this.plugin.getPortalManager().getPortals(sender, world)) {
+        for (MVPortal portal : (world == null) ? this.plugin.getPortalManager().getPortals(sender) : this.plugin.getPortalManager().getPortals(sender, world)) {
             String destination = "";
-            if(p.getDestination() != null) {
-                destination = p.getDestination().toString();
-                MultiverseWorld destWorld = this.plugin.getCore().getMVWorldManager().getMVWorld(destination);
-                if (destWorld != null) {
-                    destination = "(World) " + ChatColor.DARK_AQUA + destination;
-                } else {
-                    String destType = destination.substring(0, 1);
-                    if (destType.equals("p")) {
-                        String targetWorldName = plugin.getPortalManager().getPortal(p.getDestination().getName()).getWorld().getName();
-                        destination = "(Portal) " + ChatColor.DARK_AQUA + p.getDestination().getName() + ChatColor.GRAY + " (" + targetWorldName + ")";
-                    }
-                    if (destType.equals("e")) {
-                        String destinationWorld = p.getDestination().toString().split(":")[1];
-                        String destPart = p.getDestination().toString().split(":")[2];
-                        String[] locParts = destPart.split(",");
-                        int x, y, z;
-                        try {
-                            x = (int) Double.parseDouble(locParts[0]);
-                            y = (int) Double.parseDouble(locParts[1]);
-                            z = (int) Double.parseDouble(locParts[2]);
-                        } catch(NumberFormatException e) {
-                            e.printStackTrace();
-                            continue;
-                        }
-                        destination = "(Location) " + ChatColor.DARK_AQUA + destinationWorld + ", " + x + ", " + y + ", " + z;
+            if(portal.getDestination() != null) {
+                destination = portal.getDestination().toString();
+                String destType = portal.getDestination().getIdentifier();
+                if(destType.equals("w")) {
+                    MultiverseWorld destWorld = this.plugin.getCore().getMVWorldManager().getMVWorld(destination);
+                    if (destWorld != null) {
+                        destination = "(World) " + ChatColor.DARK_AQUA + destination;
                     }
                 }
+                if (destType.equals("p")) {
+                    String targetWorldName = plugin.getPortalManager().getPortal(portal.getDestination().getName()).getWorld().getName();
+                    destination = "(Portal) " + ChatColor.DARK_AQUA + portal.getDestination().getName() + ChatColor.GRAY + " (" + targetWorldName + ")";
+                }
+                if (destType.equals("e")) {
+                    String destinationWorld = portal.getDestination().toString().split(":")[1];
+                    String destPart = portal.getDestination().toString().split(":")[2];
+                    String[] locParts = destPart.split(",");
+                    int x, y, z;
+                    try {
+                        x = (int) Double.parseDouble(locParts[0]);
+                        y = (int) Double.parseDouble(locParts[1]);
+                        z = (int) Double.parseDouble(locParts[2]);
+                    } catch(NumberFormatException e) {
+                        e.printStackTrace();
+                        continue;
+                    }
+                    destination = "(Location) " + ChatColor.DARK_AQUA + destinationWorld + ", " + x + ", " + y + ", " + z;
+                }
             }
-            if (p.getName().matches("(i?).*" + filter + ".*") || ( p.getDestination() != null && destination.matches("(i?).*" + filter + ".*"))) {
-                portals.add(ChatColor.YELLOW + p.getName() + ((p.getDestination() != null) ? (ChatColor.AQUA + " -> " + ChatColor.GOLD + destination) : ""));
+
+            if (portal.getName().toLowerCase().contains(filter.toLowerCase()) || ( portal.getDestination() != null && destination.toLowerCase().contains(filter.toLowerCase()))) {
+                portals.add(ChatColor.YELLOW + portal.getName() + ((portal.getDestination() != null) ? (ChatColor.AQUA + " -> " + ChatColor.GOLD + destination) : ""));
             }
         }
         java.util.Collections.sort(portals);


### PR DESCRIPTION
To make a better list command, I changed the default appended names to a list view with multiple pages.
Also you can, instead of a filter, type the page you want to get the portals.
As further little enhancement, I added the destination portal name into the line of the portal's entry if there's a destination set.
Here some images as explanation:

Old:
![image](https://user-images.githubusercontent.com/18233867/116793958-22451300-aaca-11eb-9f9b-b0fc8e93e080.png)

New:
![image](https://user-images.githubusercontent.com/18233867/116793994-4e609400-aaca-11eb-9cef-5a818fab76b8.png)
![image](https://user-images.githubusercontent.com/18233867/116793999-5d474680-aaca-11eb-91b6-3875e3ac4e0d.png)
![image](https://user-images.githubusercontent.com/18233867/116794006-6b956280-aaca-11eb-91cb-8df5c9f008f1.png)

Sadly, you're not able to use a filter and group by pages at the same time.