### PR TITLE
Ensure portal name won't cause yaml saving issues.

### DIFF
--- a/src/main/java/com/onarandombox/MultiversePortals/MVPortal.java
+++ b/src/main/java/com/onarandombox/MultiversePortals/MVPortal.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.Stack;
 import java.util.logging.Level;
+import java.util.regex.Pattern;
 
 import com.dumptruckman.minecraft.util.Logging;
 import com.onarandombox.MultiverseCore.utils.MaterialConverter;
@@ -55,6 +56,8 @@ public class MVPortal {
 
     private static final Collection<Material> INTERIOR_MATERIALS = Arrays.asList(Material.NETHER_PORTAL, Material.GRASS,
             Material.VINE, Material.SNOW, Material.AIR, Material.WATER, Material.LAVA);
+
+    public static final Pattern PORTAL_NAME_PATTERN = Pattern.compile("[a-zA-Z0-9_-]+");
 
     public static boolean isPortalInterior(Material material) {
         return INTERIOR_MATERIALS.contains(material);

--- a/src/main/java/com/onarandombox/MultiversePortals/commands/CreateCommand.java
+++ b/src/main/java/com/onarandombox/MultiversePortals/commands/CreateCommand.java
@@ -57,16 +57,23 @@ public class CreateCommand extends PortalCommand {
         if (r == null) {
             return;
         }
-        MVPortal portal = this.plugin.getPortalManager().getPortal(args.get(0));
+
+        String portalName = args.get(0);
+        if (!MVPortal.PORTAL_NAME_PATTERN.matcher(portalName).matches()) {
+            sender.sendMessage(String.format("%sInvalid portal name. It must not contain dot or special characters.", ChatColor.RED));
+            return;
+        }
+
+        MVPortal portal = this.plugin.getPortalManager().getPortal(portalName);
         PortalLocation location = new PortalLocation(r.getMinimumPoint(), r.getMaximumPoint(), world);
-        if (this.plugin.getPortalManager().addPortal(world, args.get(0), p.getName(), location)) {
-            sender.sendMessage("New portal (" + ChatColor.DARK_AQUA + args.get(0) + ChatColor.WHITE + ") created and selected!");
+        if (this.plugin.getPortalManager().addPortal(world, portalName, p.getName(), location)) {
+            sender.sendMessage("New portal (" + ChatColor.DARK_AQUA + portalName + ChatColor.WHITE + ") created and selected!");
             // If the portal did not exist, ie: we're creating it.
             // we have to re select it, because it would be null
-            portal = this.plugin.getPortalManager().getPortal(args.get(0));
+            portal = this.plugin.getPortalManager().getPortal(portalName);
 
         } else {
-            sender.sendMessage("New portal (" + ChatColor.DARK_AQUA + args.get(0) + ChatColor.WHITE + ") was NOT created!");
+            sender.sendMessage("New portal (" + ChatColor.DARK_AQUA + portalName + ChatColor.WHITE + ") was NOT created!");
             sender.sendMessage("It already existed and has been selected.");
         }
 


### PR DESCRIPTION
Fixes #589. Often ppl create names with dots such as `world.one` which will save incorrectly in YAML:
```
world:
  one:
    # data at the wrong place.
```

The solution is just to disallow such names.