### PR TITLE
Properly allow turning off safe teleport.

### DIFF
--- a/src/main/java/com/onarandombox/MultiversePortals/MVPortal.java
+++ b/src/main/java/com/onarandombox/MultiversePortals/MVPortal.java
@@ -371,7 +371,6 @@ public class MVPortal {
             return this.setDestination(value);
         }
 
-
         if (property.equalsIgnoreCase("curr") || property.equalsIgnoreCase("currency")) {
             return this.setCurrency(Material.matchMaterial(value));
         }
@@ -387,25 +386,33 @@ public class MVPortal {
         if (property.equalsIgnoreCase("owner")) {
             return this.setOwner(value);
         }
+
         if (property.equalsIgnoreCase("safe")) {
             try {
                 this.setUseSafeTeleporter(Boolean.parseBoolean(value));
                 return true;
-            } catch (Exception e) {
-
+            } catch (Exception ignored) {
             }
         }
+
         if (property.equalsIgnoreCase("telenonplayers")) {
             try {
                 this.setTeleportNonPlayers(Boolean.parseBoolean(value));
                 return true;
-            } catch (Exception e) {
+            } catch (Exception ignored) {
             }
         }
+
         if (property.equalsIgnoreCase("handlerscript")) {
             this.setHandlerScript(value);
             return true;
         }
+
+        if (property.equalsIgnoreCase("safeteleport")) {
+            this.setUseSafeTeleporter(Boolean.parseBoolean(value));
+            return true;
+        }
+
         return false;
     }
 

--- a/src/main/java/com/onarandombox/MultiversePortals/PortalPlayerSession.java
+++ b/src/main/java/com/onarandombox/MultiversePortals/PortalPlayerSession.java
@@ -335,4 +335,8 @@ public class PortalPlayerSession {
 
         return (cooldownMs / 1000) + "s";
     }
+
+    public Player getPlayer() {
+        return player;
+    }
 }

--- a/src/main/java/com/onarandombox/MultiversePortals/destination/PortalDestination.java
+++ b/src/main/java/com/onarandombox/MultiversePortals/destination/PortalDestination.java
@@ -145,7 +145,7 @@ public class PortalDestination implements MVDestination {
 
     @Override
     public boolean useSafeTeleporter() {
-        return this.portal.useSafeTeleporter();
+        return true;
     }
 
 }

--- a/src/main/java/com/onarandombox/MultiversePortals/enums/SetProperties.java
+++ b/src/main/java/com/onarandombox/MultiversePortals/enums/SetProperties.java
@@ -8,5 +8,5 @@
 package com.onarandombox.MultiversePortals.enums;
 
 public enum SetProperties {
-    destination, dest, owner, loc, location, price, currency, curr, safe, telenonplayers, handlerscript
+    destination, dest, owner, loc, location, price, currency, curr, safe, telenonplayers, handlerscript, safeteleport;
 }

--- a/src/main/java/com/onarandombox/MultiversePortals/listeners/MVPPlayerListener.java
+++ b/src/main/java/com/onarandombox/MultiversePortals/listeners/MVPPlayerListener.java
@@ -258,9 +258,14 @@ public class MVPPlayerListener implements Listener {
                 }
 
                 event.setTo(destLocation);
-                if (portalDest.useSafeTeleporter()) {
+                if (portal.useSafeTeleporter()) {
                     SafeTTeleporter teleporter = this.plugin.getCore().getSafeTTeleporter();
-                    event.setTo(teleporter.getSafeLocation(event.getPlayer(), portalDest));
+                    Location safeLocation = teleporter.getSafeLocation(event.getPlayer(), portalDest);
+                    if (safeLocation == null) {
+                        Logging.fine("Player denied teleportation as no safe location is found.");
+                        return;
+                    }
+                    event.setTo(safeLocation);
                 }
 
                 PortalPlayerSession ps = this.plugin.getPortalSession(event.getPlayer());

--- a/src/main/java/com/onarandombox/MultiversePortals/listeners/MVPPlayerMoveListener.java
+++ b/src/main/java/com/onarandombox/MultiversePortals/listeners/MVPPlayerMoveListener.java
@@ -7,12 +7,8 @@
 
 package com.onarandombox.MultiversePortals.listeners;
 
-import java.util.Date;
-import java.util.logging.Level;
-
 import com.dumptruckman.minecraft.util.Logging;
 import com.onarandombox.MultiverseCore.api.MVDestination;
-import com.onarandombox.MultiverseCore.api.MultiverseWorld;
 import com.onarandombox.MultiverseCore.destination.InvalidDestination;
 import com.onarandombox.MultiverseCore.utils.MVEconomist;
 import com.onarandombox.MultiversePortals.MVPortal;
@@ -93,11 +89,13 @@ public class MVPPlayerMoveListener implements Listener {
                 return;
             }
 
+            Logging.warning("Getting location...");
             Location destLocation = d.getLocation(p);
             if (destLocation == null) {
                 Logging.fine("Unable to teleport player because destination is null!");
                 return;
             }
+            Logging.warning("Got location.");
 
             if (!this.plugin.getCore().getMVWorldManager().isMVWorld(destLocation.getWorld())) {
                 Logging.fine("Unable to teleport player because the destination world is not managed by Multiverse!");
@@ -112,7 +110,7 @@ public class MVPPlayerMoveListener implements Listener {
                     try {
                         if (helper.scriptPortal(event.getPlayer(), d, portal, ps)) {
                             // Portal handled by script
-                            helper.performTeleport(event.getPlayer(), event.getTo(), ps, d);
+                            helper.performTeleport(ps, d);
                         }
                         return;
                     } catch (IllegalStateException ignore) {
@@ -152,7 +150,7 @@ public class MVPPlayerMoveListener implements Listener {
                                 price > 0D ? "been charged" : "earned",
                                 economist.formatPrice(price, currency),
                                 portal.getName()));
-                        helper.performTeleport(event.getPlayer(), event.getTo(), ps, d);
+                        helper.performTeleport(ps, d);
                     }
                 } else {
                     p.sendMessage(economist.getNSFMessage(currency,
@@ -164,7 +162,7 @@ public class MVPPlayerMoveListener implements Listener {
                 MVPortalEvent portalEvent = new MVPortalEvent(d, event.getPlayer(), agent, portal);
                 this.plugin.getServer().getPluginManager().callEvent(portalEvent);
                 if (!portalEvent.isCancelled()) {
-                    helper.performTeleport(event.getPlayer(), event.getTo(), ps, d);
+                    helper.performTeleport(ps, d);
                 }
             }
         }

--- a/src/main/java/com/onarandombox/MultiversePortals/listeners/MVPPlayerMoveListener.java
+++ b/src/main/java/com/onarandombox/MultiversePortals/listeners/MVPPlayerMoveListener.java
@@ -89,13 +89,11 @@ public class MVPPlayerMoveListener implements Listener {
                 return;
             }
 
-            Logging.warning("Getting location...");
             Location destLocation = d.getLocation(p);
             if (destLocation == null) {
                 Logging.fine("Unable to teleport player because destination is null!");
                 return;
             }
-            Logging.warning("Got location.");
 
             if (!this.plugin.getCore().getMVWorldManager().isMVWorld(destLocation.getWorld())) {
                 Logging.fine("Unable to teleport player because the destination world is not managed by Multiverse!");


### PR DESCRIPTION
Fixes #633.

Each mv-portal have this `safeteleport` config option. This makes it such that the option applies to the portal's destination instead. 