### PR TITLE
Bump worldedit dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -177,7 +177,7 @@
         <dependency>
             <groupId>com.sk89q.worldedit</groupId>
             <artifactId>worldedit-bukkit</artifactId>
-            <version>7.0.0-SNAPSHOT</version>
+            <version>7.2.8</version>
             <type>jar</type>
             <scope>provided</scope>
             <exclusions>


### PR DESCRIPTION
Looks like actions is failing bcu 7.0.0-SNAPSHOT isn't found in maven repo for some reason