### PR TITLE
build: Update worldedit repo and dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         </repository>
         <repository>
             <id>world-edit</id>
-            <url>https://maven.sk89q.com/repo/</url>
+            <url>https://maven.enginehub.org/repo/</url>
          </repository>
         <repository>
             <id>rlf-mvn-repo</id>
@@ -177,7 +177,7 @@
         <dependency>
             <groupId>com.sk89q.worldedit</groupId>
             <artifactId>worldedit-bukkit</artifactId>
-            <version>7.2.8</version>
+            <version>7.2.9</version>
             <type>jar</type>
             <scope>provided</scope>
             <exclusions>


### PR DESCRIPTION
Looks like enginehub changed their maven repo domain, so updated that and also the worldedit dependency version while I was at it.